### PR TITLE
fix expression bug

### DIFF
--- a/framework/Templating/Compilers/ExpressionCompiler.php
+++ b/framework/Templating/Compilers/ExpressionCompiler.php
@@ -9,7 +9,7 @@ class ExpressionCompiler implements CompilerInterface
      *
      * @var string
      */
-    private $expression = '/\{{2}(.+)\}{2}/';
+    private $expression = '/\{{2}(.+?)\}{2}/';
 
     /**
      * The content to compile.


### PR DESCRIPTION
two expressions on the same line would be interpreted as one